### PR TITLE
Include project.godot in repository and remove from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ export_presets.cfg
 default_env.tres
 icon.png
 icon.png.import
-project.godot
 
 # Imported translations (automatically generated from CSV files)
 *.translation

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,30 @@
+; Engine configuration file.
+; It's best edited using the editor UI and not directly,
+; since the parameters that go here are not all obvious.
+;
+; Format:
+;   [section] ; section goes between []
+;   param=value ; assign values to parameters
+
+config_version=5
+
+[application]
+
+config/name="Sylvia"
+run/main_scene="res://start_menu/start_menu.tscn"
+config/features=PackedStringArray("4.2")
+config/icon="res://icon.svg"
+
+[display]
+
+window/size/always_on_top=true
+window/stretch/mode="2d"
+window/stretch/aspect="expand"
+window/size/width=1920
+window/size/height=1080
+window/size/test_width=1280
+window/size/test_height=720
+
+[rendering]
+
+renderer/rendering_method="mobile"


### PR DESCRIPTION
Updates the .gitignore file to stop ignoring project.godot and adds the project.godot file to the repository.This ensures consistent project settings for all team members.