### PR TITLE
Daniel/show morsel count

### DIFF
--- a/battle/BattleScene.gd
+++ b/battle/BattleScene.gd
@@ -101,11 +101,8 @@ func players_turn():
 	# player starts their turn on a food space
 	# and they have room to collect more morsels
 	if not 'collect_food' in actions_taken and current_char.can_collect_food():
-		for food in food_spaces.get_children():
-			if food.grid_pos[0] == current_char.grid_pos[0] and \
-				food.grid_pos[1] == current_char.grid_pos[1]:
-				collect_food_button.visible = true
-				break
+		if get_food_under_character():
+			collect_food_button.visible = true
 	
 	if not 'attack' in actions_taken and len(enemies_in_range(current_char.get_attack_range())) > 0:
 		attack_button.visible = true
@@ -114,11 +111,19 @@ func players_turn():
 """
 FOOD
 """
+# check if play is standing on a food space, return that food node
+func get_food_under_character():
+	for food in food_spaces.get_children():
+		if food.grid_pos == current_char.grid_pos:
+			return food
+	return null
+	
 
 func _on_collect_food_button_pressed():
 	current_char.collect_food()
 	current_char.use_action()
 	actions_taken.append('collect_food')
+	get_food_under_character().queue_free() # make that food item disapear.
 	players_turn()
 
 """

--- a/battle/BattleScene.gd
+++ b/battle/BattleScene.gd
@@ -24,6 +24,7 @@ enum State {
 @onready var food_spaces = $FoodSpaces
 @onready var spaces = $Spaces
 @onready var enemies = $Enemies
+@onready var food_counter = $FoodCounter
 
 var gamestate = State.PLAYER_TURN
 var actions_taken = []
@@ -124,6 +125,7 @@ func _on_collect_food_button_pressed():
 	current_char.use_action()
 	actions_taken.append('collect_food')
 	get_food_under_character().queue_free() # make that food item disapear.
+	food_counter.increment_count() # increment the food counter
 	players_turn()
 
 """

--- a/battle/BattleScene.tscn
+++ b/battle/BattleScene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://srh7fu8uprij"]
+[gd_scene load_steps=16 format=3 uid="uid://srh7fu8uprij"]
 
 [ext_resource type="Texture2D" uid="uid://dkushodgai21s" path="res://assets/background.png" id="1"]
 [ext_resource type="Script" path="res://battle/BattleScene.gd" id="1_vb5nx"]
@@ -12,6 +12,7 @@
 [ext_resource type="AudioStream" uid="uid://88wruo2jyoh8" path="res://Music/battle_music (surf).ogg" id="10_i4mvg"]
 [ext_resource type="PackedScene" uid="uid://dxqbt1cqviw66" path="res://card_ui/card_ui.tscn" id="11_23mjc"]
 [ext_resource type="Script" path="res://battle_ui/hand.gd" id="11_o3fgr"]
+[ext_resource type="PackedScene" uid="uid://d0dini4k6lsu7" path="res://battle_ui/food_count.tscn" id="13_dakvr"]
 
 [sub_resource type="GDScript" id="GDScript_76nkh"]
 script/source = "extends Button
@@ -319,6 +320,13 @@ text = "Attack"
 
 [node name="EndOfTurn" parent="." instance=ExtResource("7_np6ef")]
 position = Vector2(56, 88)
+
+[node name="FoodCounter" parent="." instance=ExtResource("13_dakvr")]
+offset_left = 136.0
+offset_top = 88.0
+offset_right = 136.0
+offset_bottom = 88.0
+scale = Vector2(0.836259, 0.836259)
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("10_i4mvg")

--- a/battle/BattleScene.tscn
+++ b/battle/BattleScene.tscn
@@ -250,6 +250,19 @@ collision_layer = 2
 collision_mask = 0
 grid_pos = [6, 4]
 
+[node name="FoodSpaces" type="Node2D" parent="."]
+
+[node name="Food" parent="FoodSpaces" instance=ExtResource("9_1n73l")]
+position = Vector2(339, 182)
+
+[node name="Food2" parent="FoodSpaces" instance=ExtResource("9_1n73l")]
+position = Vector2(280, 126)
+grid_pos = [1, 1]
+
+[node name="Food3" parent="FoodSpaces" instance=ExtResource("9_1n73l")]
+position = Vector2(576, 182)
+grid_pos = [6, 2]
+
 [node name="Enemies" type="Node2D" parent="."]
 
 [node name="Jerry" parent="Enemies" instance=ExtResource("8_kyk1e")]
@@ -291,8 +304,9 @@ text = "Collect Food"
 layout_mode = 0
 offset_left = 8.0
 offset_top = 213.0
-offset_right = 191.0
+offset_right = 165.0
 offset_bottom = 247.0
+theme_override_font_sizes/font_size = 17
 text = "Finish Movement"
 
 [node name="AttackButton" type="Button" parent="UI/Control"]
@@ -305,11 +319,6 @@ text = "Attack"
 
 [node name="EndOfTurn" parent="." instance=ExtResource("7_np6ef")]
 position = Vector2(56, 88)
-
-[node name="FoodSpaces" type="Node2D" parent="."]
-
-[node name="Food" parent="FoodSpaces" instance=ExtResource("9_1n73l")]
-position = Vector2(339, 182)
 
 [node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("10_i4mvg")
@@ -331,9 +340,9 @@ anchors_preset = 2
 anchor_top = 1.0
 anchor_bottom = 1.0
 offset_left = 4.0
-offset_top = -108.041
+offset_top = -95.0
 offset_right = 176.0
-offset_bottom = -52.041
+offset_bottom = -39.0
 grow_vertical = 0
 alignment = 1
 script = ExtResource("11_o3fgr")

--- a/battle/food.gd
+++ b/battle/food.gd
@@ -1,6 +1,6 @@
 extends Node2D
 
-var grid_pos = [2, 2]
+@export var grid_pos = [2, 2]
 
 # TODO: Respawn Food at a random location after collecting a morsel.
 func set_grid_pos(x, y):

--- a/battle/hearts_container.tscn
+++ b/battle/hearts_container.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=3 uid="uid://blul8swm87aem"]
+[gd_scene load_steps=3 format=3 uid="uid://blul8swm87aem"]
 
 [ext_resource type="Script" path="res://battle/hearts_container.gd" id="1_x0vii"]
+[ext_resource type="PackedScene" uid="uid://bk4y0qroc24of" path="res://battle/heart_gui.tscn" id="2_q6cd4"]
 
 [node name="heartsContainer" type="HBoxContainer"]
 offset_left = -28.0
@@ -11,3 +12,12 @@ size_flags_horizontal = 3
 theme_override_constants/separation = 1
 alignment = 1
 script = ExtResource("1_x0vii")
+
+[node name="heartGUI" parent="." instance=ExtResource("2_q6cd4")]
+layout_mode = 2
+
+[node name="heartGUI2" parent="." instance=ExtResource("2_q6cd4")]
+layout_mode = 2
+
+[node name="heartGUI3" parent="." instance=ExtResource("2_q6cd4")]
+layout_mode = 2

--- a/battle_ui/food_count.gd
+++ b/battle_ui/food_count.gd
@@ -1,0 +1,24 @@
+extends Control
+
+# the current count of collected food items.
+var food_count: int = 0
+
+# reference to the Label node to display the count.
+@onready var label: Label = $Sprite2D/Label
+
+func _ready():
+	update_label() # initializes with 0
+
+func increment_count():
+	# increments the count by one.
+	food_count += 1
+	update_label()
+
+func set_count(value: int):
+	# sets the count to a specific number.
+	food_count = value
+	update_label()
+
+func update_label():
+	# updates the label with the current count.
+	label.text = str(food_count)

--- a/battle_ui/food_count.tscn
+++ b/battle_ui/food_count.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=3 format=3 uid="uid://d0dini4k6lsu7"]
+
+[ext_resource type="Texture2D" uid="uid://ci27jwlgn78tc" path="res://assets/apple.png" id="1_lcmds"]
+[ext_resource type="Script" path="res://battle_ui/food_count.gd" id="1_riikw"]
+
+[node name="FoodCounter" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_riikw")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+scale = Vector2(4.91667, 4.91667)
+texture = ExtResource("1_lcmds")
+
+[node name="Label" type="Label" parent="Sprite2D"]
+anchors_preset = -1
+offset_left = -1.62712
+offset_top = -2.44068
+offset_right = 22.3729
+offset_bottom = 42.5593
+scale = Vector2(0.153307, 0.195869)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 36
+text = "0"
+horizontal_alignment = 1
+vertical_alignment = 1
+metadata/_edit_use_anchors_ = true


### PR DESCRIPTION
I modified the battle scene to have 3 food items to make it clearer when you've collected an item. I've also made food items disappear once collected.


For now, the morsel count is the food asset with a label on top that counts the number of morsels you've collected. The FoodCounter is currently updated when you press the collect food button.

![image](https://github.com/Endermandels/Sylvia/assets/42653318/e8ea1a4e-2b06-4bb2-9ca9-dc57c038b853)

resolves #99 