### PR TITLE
Map Generation System Backend

### DIFF
--- a/battle/BattleScene.tscn
+++ b/battle/BattleScene.tscn
@@ -1,11 +1,8 @@
-
-[gd_scene load_steps=13 format=3 uid="uid://srh7fu8uprij"]
+[gd_scene load_steps=15 format=3 uid="uid://srh7fu8uprij"]
 
 [ext_resource type="Texture2D" uid="uid://dkushodgai21s" path="res://assets/background.png" id="1"]
 [ext_resource type="Script" path="res://battle/BattleScene.gd" id="1_vb5nx"]
 [ext_resource type="PackedScene" uid="uid://dgk0dpadx1wkc" path="res://battle/Space.tscn" id="2"]
-[ext_resource type="Texture2D" uid="uid://bitai2b163x1n" path="res://assets/card.png" id="3"]
-
 [ext_resource type="Texture2D" uid="uid://cifdlrxp33p1u" path="res://assets/grid.png" id="5"]
 [ext_resource type="PackedScene" uid="uid://bub37ipigql3v" path="res://battle/Character.tscn" id="7"]
 [ext_resource type="PackedScene" uid="uid://d2x4fgnxceh5u" path="res://battle/end_of_turn.tscn" id="7_np6ef"]

--- a/overworld/MapGenerator.gd
+++ b/overworld/MapGenerator.gd
@@ -1,0 +1,167 @@
+class_name MapGenerator
+extends Node
+
+var map_data: Array[Array]
+#the distance between each node (the spacing between an array of dots)
+const X_DIST := 30
+const Y_DIST := 25
+#setting to control how "wild" the map can look (how far each dot can vary from it's position)
+const PLACEMENT_RANDOMNESS := 5
+#i, the number of rows
+const FLOORS := 15
+#j, the width of the rows
+const MAP_WIDTH := 7
+#how many possible PATHS there can be
+const PATHS := 6
+#weighting for each map_space's chance when receiving a type
+const ENEMY_ROOM_WEIGHT := 10.0
+const SHOP_ROOM_WEIGHT := 2.5
+const EVENT_ROOM_WEIGHT := 4.0
+
+var random_room_type_weights = {
+	map_space.Type.ENEMY: 0.0,
+	map_space.Type.SHOP: 0.0,
+	map_space.Type.EVENT: 0.0
+}
+var random_room_type_total_weight := 0
+
+
+func _ready() -> void:
+	generate_map()
+
+
+func generate_map() -> Array[Array]:
+	#generate an empty grid of map_spaces
+	map_data = _generate_initial_grid()
+	#get our starting points: a list with PATHS values, ranging from (0-MAP_WIDTH-1)
+	#and containing at least 2 unique points, ie [1,1,1,1,1,2] or [4,3,2,6,5,4]
+	var starting_points := _get_random_starting_points()
+	#for each starting point, create a path from the starting point to the boss
+	for j in starting_points:
+		var current_j := j
+		for i in FLOORS - 1:
+			current_j = _setup_connection(i, current_j)
+	
+	#for testing, will print the following 2 lines for each floor:
+	#floor x
+	#[column (type), column (type), ...] 
+	#where type is the 2nd character of the type (so it's unique, ie {O, N, V, H})		
+	#and it only prints map_spaces that have a next_room that isn't empy (part of a path)
+	var i := 0
+	for floors in map_data:
+		print("floor %s" % i)
+		var used_rooms = floors.filter(
+			func(rooms: map_space): return rooms.next_rooms.size() > 0
+		)
+		print(used_rooms)
+		i += 1
+
+	return map_data
+	
+#returns a 2d array of map_spaces with position values initialized to match the 2d array,
+#no next_rooms connections, and with enumeration type NO_TYPE
+func _generate_initial_grid() -> Array[Array]:
+	var result: Array[Array] = []
+	for i in FLOORS:
+		#make a new floor named adj_rooms to add to our result
+		var adj_rooms: Array[map_space]= []
+		#fill adj_rooms with new map_spaces
+		for j in MAP_WIDTH:
+			var current_room := map_space.new()
+			var offset := Vector2(randf(), randf()) * PLACEMENT_RANDOMNESS
+			#the offset is used to make the map look more interesting
+			current_room.positioning = Vector2(j * X_DIST, i * -Y_DIST) + offset
+			current_room.row = i
+			current_room.column = j
+			current_room.next_rooms = []
+			#boss room has no offset, is a little higher
+			if i == FLOORS - 1:
+				current_room.positioning.y = (i + 1) * -Y_DIST
+			#add current room to the floor (aka adj_rooms)
+			adj_rooms.append(current_room)
+		#add the floor (aka adj_rooms) to our results
+		result.append(adj_rooms)
+	
+	return result
+	
+#returns an array of ints of length PATHS to use as starting points, 
+#ie [1, 3, 1, 4, 5, 1] or [2, 4, 4, 4, 4, 4]. guaranteed to have 2 unique values
+func _get_random_starting_points() -> Array[int]:
+	var y_coordinates: Array[int]
+	var unique_points: int = 0
+	
+	#keeps resetting until at least 2 unique points are rolled
+	while unique_points < 2:
+		unique_points = 0
+		y_coordinates = []
+		
+		for i in PATHS:
+			#this could potentially roll the same thing for each PATHS we want to take
+			#ie [1,1,1,1,1,1] in which case the reset happens. [1,1,1,1,1,2] would pass
+			var starting_point := randi_range(0, MAP_WIDTH - 1)
+			if not y_coordinates.has(starting_point):
+				unique_points += 1
+				
+			y_coordinates.append(starting_point)
+			
+	return y_coordinates
+	
+#makes a connection from i, j to i+1 (next floor) and j-1, j, or j+1 
+#calls a function before setup to ensure we do not cross paths with the left
+#or right neighbors
+func _setup_connection(i: int, j: int) -> int:
+	#
+	var next_room: map_space
+	var current_room := map_data[i][j] as map_space
+	#on first run next_room is false so it runs the loop, then on the next run
+	#it checks _would_cross_existing_path() to make sure neither neighbor (j-1, j+1)
+	#has a connection that would be crossed by this connection
+	while not next_room or _would_cross_existing_path(i, j, next_room):
+		var random_j := clampi(randi_range(j - 1, j + 1), 0, MAP_WIDTH - 1)
+		next_room = map_data[i + 1][random_j]
+	#add the connection
+	current_room.next_rooms.append(next_room)
+	
+	return next_room.column
+		
+#returns true if the connection from [i,j] to map_space's i,j would cross
+#any connections established by the left or right neighbor (j-1, j+1)
+func _would_cross_existing_path(i: int, j: int, space: map_space) -> bool:
+	var left_neighbor: map_space
+	var right_neighbor: map_space
+	
+	#make sure we have a left neighbor and set it
+	if j > 0:
+		left_neighbor = map_data[i][j-1]
+	#make sure we have a right neighbor and set it
+	if j < MAP_WIDTH - 1:
+		right_neighbor = map_data[i][j+1]
+	
+	#check our right neighbor and whether there's a chance we can cross connections
+	if right_neighbor and space.column > j:
+		for next_room: map_space in right_neighbor.next_rooms:
+			if next_room.column < space.column: 
+				return true
+	
+	#check our left neighbor and whether there's a chance we can cross connections
+	if left_neighbor and space.column < j:
+		for next_room: map_space in left_neighbor.next_rooms:
+			if next_room.column > space.column:
+				return true
+				
+	return false
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	

--- a/overworld/Overworld.tscn
+++ b/overworld/Overworld.tscn
@@ -1,13 +1,9 @@
-[gd_scene load_steps=10 format=3 uid="uid://ciygfyllvwgoa"]
+[gd_scene load_steps=6 format=3 uid="uid://ciygfyllvwgoa"]
 
 [ext_resource type="Texture2D" uid="uid://c0lc0q4evr4jg" path="res://assets/background_brown.png" id="1_u7u2j"]
 [ext_resource type="Script" path="res://overworld/View Characters.gd" id="2_53q78"]
 [ext_resource type="Script" path="res://overworld/View Decks.gd" id="3_6c3lq"]
-[ext_resource type="PackedScene" uid="uid://cutxjovwrqa24" path="res://overworld/map_space.tscn" id="4_tca60"]
-[ext_resource type="Texture2D" uid="uid://bv644lx4cgdho" path="res://assets/map_player.png" id="5_08g2d"]
-[ext_resource type="Texture2D" uid="uid://48hkerx52bn" path="res://assets/map_enemy.png" id="6_fybd1"]
-[ext_resource type="Texture2D" uid="uid://cfhp6lmgf0vvb" path="res://assets/map_event.png" id="7_gemks"]
-[ext_resource type="Texture2D" uid="uid://dgfmeavsuqd20" path="res://assets/map_shop.png" id="8_uej0p"]
+[ext_resource type="Script" path="res://overworld/MapGenerator.gd" id="9_g26n1"]
 
 [sub_resource type="GDScript" id="GDScript_8ndto"]
 script/source = "extends Button
@@ -22,7 +18,7 @@ func _on_pressed():
 [node name="Overworld" type="Node2D"]
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
-position = Vector2(320, 182)
+position = Vector2(319, 181)
 scale = Vector2(0.552083, 0.555556)
 texture = ExtResource("1_u7u2j")
 
@@ -49,65 +45,9 @@ layout_mode = 2
 text = "View Decks"
 script = ExtResource("3_6c3lq")
 
-[node name="Map" type="Node2D" parent="."]
-
-[node name="map_space" parent="Map" instance=ExtResource("4_tca60")]
-position = Vector2(231, 192)
-
-[node name="Sprite2D" parent="Map/map_space" index="0"]
-texture = ExtResource("5_08g2d")
-
-[node name="map_space2" parent="Map" instance=ExtResource("4_tca60")]
-position = Vector2(300, 142)
-
-[node name="Sprite2D" parent="Map/map_space2" index="0"]
-texture = ExtResource("6_fybd1")
-
-[node name="map_space3" parent="Map" instance=ExtResource("4_tca60")]
-position = Vector2(298, 245)
-
-[node name="Sprite2D" parent="Map/map_space3" index="0"]
-texture = ExtResource("7_gemks")
-
-[node name="map_space4" parent="Map" instance=ExtResource("4_tca60")]
-position = Vector2(400, 143)
-
-[node name="Sprite2D" parent="Map/map_space4" index="0"]
-texture = ExtResource("8_uej0p")
-
-[node name="map_space5" parent="Map" instance=ExtResource("4_tca60")]
-position = Vector2(401, 246)
-
-[node name="Sprite2D" parent="Map/map_space5" index="0"]
-texture = ExtResource("6_fybd1")
-
-[node name="map_space6" parent="Map" instance=ExtResource("4_tca60")]
-position = Vector2(497, 141)
-
-[node name="Sprite2D" parent="Map/map_space6" index="0"]
-texture = ExtResource("7_gemks")
-
-[node name="map_space7" parent="Map" instance=ExtResource("4_tca60")]
-position = Vector2(495, 248)
-
-[node name="Sprite2D" parent="Map/map_space7" index="0"]
-texture = ExtResource("8_uej0p")
-
-[node name="map_space8" parent="Map" instance=ExtResource("4_tca60")]
-position = Vector2(568, 192)
-
-[node name="TextureButton" parent="Map/map_space8" index="1"]
-metadata/_edit_use_anchors_ = true
+[node name="MapGenerator" type="Node2D" parent="."]
+script = ExtResource("9_g26n1")
 
 [connection signal="pressed" from="CanvasLayer/VBoxContainer/Quit to Menu" to="CanvasLayer/VBoxContainer/Quit to Menu" method="_on_pressed"]
 [connection signal="pressed" from="CanvasLayer/VBoxContainer/View Characters" to="CanvasLayer/VBoxContainer/View Characters" method="_on_pressed"]
 [connection signal="pressed" from="CanvasLayer/VBoxContainer/View Decks" to="CanvasLayer/VBoxContainer/View Decks" method="_on_pressed"]
-
-[editable path="Map/map_space"]
-[editable path="Map/map_space2"]
-[editable path="Map/map_space3"]
-[editable path="Map/map_space4"]
-[editable path="Map/map_space5"]
-[editable path="Map/map_space6"]
-[editable path="Map/map_space7"]
-[editable path="Map/map_space8"]

--- a/overworld/map_space.gd
+++ b/overworld/map_space.gd
@@ -1,9 +1,14 @@
+class_name map_space
 extends Node2D
 
+enum Type {NO_TYPE, ENEMY, EVENT, SHOP, BOSS}
 
-@onready var collision = $CollisionShape2D
-@onready var tex = $Sprite2D.texture.resource_path
+@export var type: Type
+@export var row: int
+@export var column: int
+@export var positioning: Vector2
+@export var next_rooms: Array[map_space]
+@export var selected: = false
 
-func _on_texture_button_pressed():
-	if tex == "res://assets/map_enemy.png":
-		get_tree().change_scene_to_file("res://battle/BattleScene.tscn")
+func _to_string() -> String:
+	return "%s (%s)" % [column, Type.keys()[type][1]]

--- a/project.godot
+++ b/project.godot
@@ -28,6 +28,12 @@ window/size/test_height=720
 "rendering]textures/canvas_textures/default_texture_filter"=0
 renderer/rendering_method="mobile"
 
+[gui]
+
+theme/custom_font="res://assets/Font/Montserrat-Regular.ttf"
+theme/default_font_hinting=2
+theme/default_font_multichannel_signed_distance_field=true
+
 [input]
 
 left_mouse={
@@ -40,11 +46,6 @@ right_mouse={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
-[gui]
-
-theme/custom_font="res://assets/Font/Montserrat-Regular.ttf"
-theme/default_font_hinting=2
-theme/default_font_multichannel_signed_distance_field=true
 
 [layer_names]
 


### PR DESCRIPTION
map_space now has enumerated type and other necessary variables, MapGenerator is used to generate a 2D array of map_spaces with variables set, including non-intersecting paths from the first floor (0) to the boss floor (14). Currently all nodes remain with enumerated type NO_TYPE, and there are no visuals for the player to interact with yet, only print messages showing the path (albeit without proof that the connections are not crossing yet).