### PR TITLE
Daniel/stop player move on top of enemy

### DIFF
--- a/battle/BattleScene.gd
+++ b/battle/BattleScene.gd
@@ -28,6 +28,7 @@ enum State {
 @onready var enemies = $Enemies
 @onready var food_counter = $FoodCounter
 @onready var audio_manager = $AudioManager
+@onready var characters = $Characters
 
 var gamestate = State.PLAYER_TURN
 var actions_taken = []
@@ -241,7 +242,7 @@ Show finish movement button if the player moves.
 func move_char():
 	if gamestate == State.PLAYER_TURN and current_char.can_act() and not 'movement' in actions_taken:
 		for space in spaces.get_children():
-			if space.has_mouse:
+			if space.has_mouse and grid_space_free(space.grid_pos):
 				if current_char.move_char(space.global_position, space.grid_pos):
 					# Need to remove other actions while moving
 					collect_food_button.visible = false
@@ -249,11 +250,19 @@ func move_char():
 					finish_movement_button.visible = true
 					moving = true
 
+#check to ensure that the grid space is free of characters and enemies.
+func grid_space_free(grid_pos):
+	for enemy in enemies.get_children():
+		if enemy.enemy_pos == grid_pos:
+			return false
+	for character in characters.get_children():
+		if character.grid_pos == grid_pos:
+			return false
+	return true
 
 """
 ATTACK
 """
-
 func _on_attack_button_pressed():
 	audio_manager.playSFX("attack")
 	print('attack')

--- a/battle/Space.gd
+++ b/battle/Space.gd
@@ -11,6 +11,8 @@ var grid_cols = 7
 var has_mouse = false
 var lit = false
 var attackable_enemy = false
+var can_move_too = false
+var enemy_present = false
 
 func _on_mouse_entered():
 	has_mouse = true
@@ -34,18 +36,27 @@ func _process(_delta):
 		attackable_enemy = false
 		color_rect.modulate = Color(1, 1, 1, 1)
 
-	if can_move_to_character(character_pos, grid_pos, moves_left, battle_scene.actions_taken) or attackable_enemy:
+	if can_move_to_character(character_pos, grid_pos, moves_left, battle_scene.actions_taken):
+		can_move_too = true
+	else:
+		can_move_too = false
+		
+	if can_move_too or attackable_enemy:
 		color_rect.color.a = 0.3
 		lit = true
 	else:
 		color_rect.color.a = 0
 		lit = false
+	if not attackable_enemy and can_move_too and enemy_present:
+		color_rect.modulate = Color(0.8, 0.4, 0, 1)
 
 func attackable_enemy_present():
 	var character_pos = character.grid_pos	# Assuming this is an array [x, y]
 	var taken_actions = battle_scene.actions_taken
+	enemy_present = false
 	for enemy in enemies.get_children():
 		if enemy.enemy_pos == grid_pos:
+			enemy_present=true
 			# Manually calculate the difference
 			var diff_x = enemy.enemy_pos[0] - character_pos[0]
 			var diff_y = enemy.enemy_pos[1] - character_pos[1]


### PR DESCRIPTION
Added a function that makes sure a grid space is free, and added a condition in move char that makes sure a space is free (from enemies or other characters) before allowing a character to move to that space.

Modified the space indicator to be like a clear orange color when an enemy is within moveable but not attack distance.

![image](https://github.com/Endermandels/Sylvia/assets/42653318/8cf0fd9d-4c30-4072-b435-a0a150654c03)
