### PR TITLE
Add Enemy Behavior

### DIFF
--- a/battle/BattleScene.gd
+++ b/battle/BattleScene.gd
@@ -82,7 +82,7 @@ func spawn_enemies( num_cols):
 		enemy.enemy_pos = [randi() % num_cols, 0]
 		enemy.update_visual_position((enemy.enemy_pos))
 	#	enemy.enemys_turn.connect(_on_battle_scene_enemys_turn)
-		
+		print("%s behavior is %s" % [enemy, enemy.behavior.Behavior])
 
 """
 INPUT

--- a/battle/Behavior.gd
+++ b/battle/Behavior.gd
@@ -1,0 +1,118 @@
+extends Node
+
+enum Behaviors {CAUTIOUS=0, NEUTRAL=1, VENGEFUL=2, AGGRESSIVE=3}
+@onready var Behavior = pick_random_behavior()
+
+# Picks a random behavior
+func pick_random_behavior():
+	return randi() % 4
+	
+# From a given turn list, choose what turn the enemy
+# would make based on its behavior.
+func choose_actions(enemy, turn_list, player_pos):
+	if Behavior == Behaviors.CAUTIOUS:
+		if enemy.stats.hp == enemy.stats.saved_hp:
+			return choose_random_turn(turn_list)
+		return cautious_turn(turn_list, player_pos)
+	
+	# A neutral behavior means the enemy makes turns randomly.
+	if Behavior == Behaviors.NEUTRAL:
+		return choose_random_turn(turn_list)
+	
+	# Vengeful enemies intially are neutral enemies until either an enemy dies
+	# or they receive damage.
+	if Behavior == Behaviors.VENGEFUL:
+		var enemies = enemy.get_parent()
+		for animal in enemies.get_children():
+			if enemy.alive == false:
+				return aggressive_turn(turn_list, player_pos)
+		if enemy.stats.hp == enemy.stats.saved_hp:
+			return choose_random_turn(turn_list)
+		return aggressive_turn(turn_list, player_pos)
+	
+	# An aggressive enemy tries to get up close to the player and attack.	
+	if Behavior == Behaviors.AGGRESSIVE:
+		return aggressive_turn(turn_list, player_pos)
+
+# Returns a random turn for a given turn list.			
+func choose_random_turn(turn_list):
+	return turn_list[randi() % len(turn_list)]
+
+# Takes a list of turns and a list of all the playable characters postions
+# and returns a list of cautious turns.
+# A cautious turn is defined as a turn where the enemy can maximize the
+# distance between the enemy and the playable characters.
+func cautious_turn(turn_list, player_pos):
+	var max_distance = 0
+	var cautious_turns = []
+	for turn in turn_list:
+		for i in range(turn.size() - 1, -1, -1):
+			var action = turn[i]
+			if action.has("move"):
+				# Assumes that the actual max distance between the enemy and
+				# the player never exceeds 100.
+				var max_turn_distance = 100
+				for pos in player_pos:
+					var distance = get_manhattan_distance(action[-1][0], pos)
+					if distance < max_turn_distance: 
+						max_turn_distance = distance
+				if max_turn_distance > max_distance:
+					max_distance = max_turn_distance
+					cautious_turns.clear()
+					cautious_turns.append(turn)
+				elif max_turn_distance == max_distance:
+					cautious_turns.append(turn)
+				break
+	return choose_random_turn(cautious_turns)
+
+# Takes a list of turns and a list of player positions and
+# returns an aggressive turn.
+func aggressive_turn(turn_list, player_pos):
+	var attack_turns = get_attack_turns(turn_list)
+	if attack_turns.size() != 0:
+		return choose_random_turn(attack_turns)
+	return approach_player(turn_list, player_pos)
+
+# Takes a list of turns and a list of player positions and
+# returns a list of turns that best minimize the distance between
+# the enemy and the player.
+func approach_player(turn_list, player_pos):
+	# Assumes that the actual max distance between the enemy and
+	# the player never exceeds 100.
+	var min_distance = 100
+	var approach_turns = []
+	for turn in turn_list:
+		for i in range(turn.size() - 1, -1, -1):
+			var action = turn[i]
+			if action.has("move"):
+				# Assumes that the actual max distance between the enemy and
+				# the player never exceeds 100.
+				var min_turn_distance = 100
+				for pos in player_pos:
+					var distance = get_manhattan_distance(action[-1][0], pos)
+					if distance < min_turn_distance: 
+						min_turn_distance = distance
+				if min_turn_distance < min_distance:
+					min_distance = min_turn_distance
+					approach_turns.clear()
+					approach_turns.append(turn)
+				elif min_turn_distance == min_distance:
+					approach_turns.append(turn)
+				break
+	return choose_random_turn(approach_turns)
+
+# Takes a turn list and returns a list of turns
+# that has attack as a action.
+func get_attack_turns(turn_list):
+	var attack_turns = []
+	for turn in turn_list:
+		for action in turn:
+			if action.has("attack"):
+				attack_turns.append(turn)
+				break
+	return attack_turns
+
+# Returns the manhattan distance between two lists
+# where each list contains two integers.
+func get_manhattan_distance(pos1, pos2):
+	return abs(pos1[0] - pos2[0]) + abs(pos1[1] - pos2[1])

--- a/battle/Enemy.gd
+++ b/battle/Enemy.gd
@@ -4,6 +4,7 @@ extends Node2D
 @onready var stats = $Stats
 @onready var hitbox = $Area2D
 @onready var enemies = $".."
+@onready var behavior = $Behavior
 #temp way to get the player
 @onready var clover = get_parent().get_parent().get_node("Characters/Clover")
 
@@ -32,9 +33,9 @@ func _on_battle_scene_enemys_turn():
 	print("All the actions for the enemy are: ")
 	for turn in turn_list:
 		print(turn)
-	var next_turn = turn_list[randi() % len(turn_list)]
-	print("Next turn will be: ")
-	print(next_turn)
+	var next_turn = behavior.choose_actions(self, turn_list, 
+	get_players_positions())
+	print("%s Next turn will be: %s" % [self, next_turn])
 	for action in next_turn:
 		callv(action[0], action[1])
 	

--- a/battle/Enemy.tscn
+++ b/battle/Enemy.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=7 format=3 uid="uid://t32b4boxehdt"]
+[gd_scene load_steps=8 format=3 uid="uid://t32b4boxehdt"]
 
 [ext_resource type="Script" path="res://battle/Enemy.gd" id="1_0foq6"]
 [ext_resource type="Texture2D" uid="uid://diabusi8j80nn" path="res://assets/enemy.png" id="2_olglr"]
 [ext_resource type="PackedScene" uid="uid://blul8swm87aem" path="res://battle/hearts_container.tscn" id="3_08k4c"]
 [ext_resource type="PackedScene" uid="uid://thokds7o172e" path="res://battle/Stats.tscn" id="3_xep2x"]
 [ext_resource type="Texture2D" uid="uid://csrbjndfygj03" path="res://assets/rip.png" id="5_my15s"]
+[ext_resource type="Script" path="res://battle/Behavior.gd" id="6_j8ofn"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_vkj6t"]
 radius = 16.0
@@ -38,3 +39,6 @@ collision_layer = 4
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 shape = SubResource("CircleShape2D_vkj6t")
+
+[node name="Behavior" type="Node" parent="."]
+script = ExtResource("6_j8ofn")


### PR DESCRIPTION
Enemy behavior determines what actions an enemy will make for a given turn.

Currently, 4 different behaviors are implemented: cautious, neutral, vengeful, and aggressive. These behaviors are currently randomly determined for each enemy at the start of each game.

Resolves #65 